### PR TITLE
Bump ncWMS2 version from 2.2.4 to 2.2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN \
     apt-get install -y unzip
 
 # ncWMS
-ENV ncWMS_VERSION 2.2.4
+ENV ncWMS_VERSION 2.2.5
 ENV WAR_URL https://github.com/Reading-eScience-Centre/ncwms/releases/download/ncwms-$ncWMS_VERSION/ncWMS2.war
 
 RUN curl -fSL "$WAR_URL" -o ncWMS.war


### PR DESCRIPTION
* v 2.2.5 provides the ability to retrieve `timeSeries` requests as `text/json` with [CoverageJson](https://covjson.org/) conventions. 