### PR TITLE
Bump version to 2.2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN \
     apt-get install -y unzip
 
 # ncWMS
-ENV ncWMS_VERSION 2.2.5
+ENV ncWMS_VERSION 2.2.6
 ENV WAR_URL https://github.com/Reading-eScience-Centre/ncwms/releases/download/ncwms-$ncWMS_VERSION/ncWMS2.war
 
 RUN curl -fSL "$WAR_URL" -o ncWMS.war

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A feature full Tomcat (SSL over APR, etc.) running [ncWMS](http://www.resc.rdg.a
 
 Available versions:
 
-* `axiom/docker-ncwms` (currently `2.2.4`) - [docker hub](https://hub.docker.com/r/axiom/docker-ncwms/builds/)
+* `axiom/docker-ncwms` (currently `2.2.6`) - [docker hub](https://hub.docker.com/r/axiom/docker-ncwms/builds/)
 
 
 ### tl;dr


### PR DESCRIPTION
Bump to [ncWMS2 version 2.2.6, released Feb 20](https://github.com/Reading-eScience-Centre/ncwms/releases)